### PR TITLE
Add Atlas plugin to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 - [session](https://github.com/gaurishhs/elysia-session) - Multi-runtime Sessions plugin.
 - [compression](https://github.com/gusb3ll/elysia-compression) - Compression plugin.
 - [Logging](https://github.com/otherguy/elysia-logging) - Logging middleware for a variety of loggers (Pino, Winston, etc.)
+- [Atlas](https://github.com/elcharitas/elysia-atlas) - File system routes with full typing inference capabilities of elysia baked in
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 - [Decorators](https://github.com/gaurishhs/elysia-decorators) - Use typescript decorators.
 - [Autoroutes](https://github.com/wobsoriano/elysia-autoroutes) - File system routes.
 - [Group Router](https://github.com/itsyoboieltr/elysia-group-router) - File system and folder-based router for groups.
+- [Atlas](https://github.com/elcharitas/elysia-atlas) - File/Folder system routes
 - [Basic Auth](https://github.com/itsyoboieltr/elysia-basic-auth) - Basic http authentication.
 - [ETag](https://github.com/bogeychan/elysia-etag) - Automatic HTTP ETags generation.
 - [Basic Auth](https://github.com/eelkevdbos/elysia-basic-auth) - Basic http authentication (using 'request' event).
@@ -99,7 +100,6 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 - [session](https://github.com/gaurishhs/elysia-session) - Multi-runtime Sessions plugin.
 - [compression](https://github.com/gusb3ll/elysia-compression) - Compression plugin.
 - [Logging](https://github.com/otherguy/elysia-logging) - Logging middleware for a variety of loggers (Pino, Winston, etc.)
-- [Atlas](https://github.com/elcharitas/elysia-atlas) - File system routes with full typing inference capabilities of elysia baked in
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 - [Decorators](https://github.com/gaurishhs/elysia-decorators) - Use typescript decorators.
 - [Autoroutes](https://github.com/wobsoriano/elysia-autoroutes) - File system routes.
 - [Group Router](https://github.com/itsyoboieltr/elysia-group-router) - File system and folder-based router for groups.
-- [Atlas](https://github.com/elcharitas/elysia-atlas) - File/Folder system routes
+- [Atlas](https://github.com/elcharitas/elysia-atlas) - File/Folder system routes.
 - [Basic Auth](https://github.com/itsyoboieltr/elysia-basic-auth) - Basic http authentication.
 - [ETag](https://github.com/bogeychan/elysia-etag) - Automatic HTTP ETags generation.
 - [Basic Auth](https://github.com/eelkevdbos/elysia-basic-auth) - Basic http authentication (using 'request' event).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated plugin list to include Atlas, a new plugin for file and folder system routes.
  * Atlas is shown in the plugin ordering at two positions: inserted between Group Router and Basic Auth in one listing, and listed immediately after Group Router in another.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->