### PR TITLE
Add Eden Stack to Boilerplates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 
 - [elysia-kickstart](https://github.com/syhner/elysia-kickstart) - ElysiaJS boilerplate with HTMX, Tailwind, Auth.js, Drizzle, CI, and Docker to deploy anywhere (including Railway and Vercel Edge Functions).
 - [dbest-stack](https://github.com/itsyoboieltr/dbest-stack) - DrizzleORM, Bun, ElysiaJS, SolidStart, Tailwind CSS stack.
+- [Eden Stack](https://github.com/edenstackdev/eden-stack) - Production-ready full-stack SaaS starter with TanStack Start, Eden Treaty, Better Auth, Drizzle, Stripe, Inngest, and Vercel deployment.
 - [elysia-routing-controllers](https://github.com/OthmanAmoudi/Elysia-routing-controllers) - Elysia RESTAPI routing controllers, Turso sqlite database with DrizzleORM.
 - [elysia-ws-event](https://github.com/Kiyo5hi/elysia-ws-event) - Event-drive Elysia WebSocket server.
 - [elysia-clean-architecture](https://github.com/lukas-andre/bun-elysia-clean-architecture-example) - ElysiaJS, Bun, Postgres.js + Clean Architecture API example

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 
 - [elysia-kickstart](https://github.com/syhner/elysia-kickstart) - ElysiaJS boilerplate with HTMX, Tailwind, Auth.js, Drizzle, CI, and Docker to deploy anywhere (including Railway and Vercel Edge Functions).
 - [dbest-stack](https://github.com/itsyoboieltr/dbest-stack) - DrizzleORM, Bun, ElysiaJS, SolidStart, Tailwind CSS stack.
-- [Eden Stack](https://eden-stack.com) - Production-ready full-stack SaaS starter with TanStack Start, Eden Treaty, Better Auth, Drizzle, Stripe, Inngest, and Vercel deployment.
+- [Eden Stack](https://eden-stack.com?utm_source=github&utm_medium=awesome-list&utm_campaign=backlinks) - Production-ready full-stack SaaS starter with TanStack Start, Eden Treaty, Better Auth, Drizzle, Stripe, Inngest, and Vercel deployment.
 - [elysia-routing-controllers](https://github.com/OthmanAmoudi/Elysia-routing-controllers) - Elysia RESTAPI routing controllers, Turso sqlite database with DrizzleORM.
 - [elysia-ws-event](https://github.com/Kiyo5hi/elysia-ws-event) - Event-drive Elysia WebSocket server.
 - [elysia-clean-architecture](https://github.com/lukas-andre/bun-elysia-clean-architecture-example) - ElysiaJS, Bun, Postgres.js + Clean Architecture API example

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 
 - [elysia-kickstart](https://github.com/syhner/elysia-kickstart) - ElysiaJS boilerplate with HTMX, Tailwind, Auth.js, Drizzle, CI, and Docker to deploy anywhere (including Railway and Vercel Edge Functions).
 - [dbest-stack](https://github.com/itsyoboieltr/dbest-stack) - DrizzleORM, Bun, ElysiaJS, SolidStart, Tailwind CSS stack.
-- [Eden Stack](https://github.com/edenstackdev/eden-stack) - Production-ready full-stack SaaS starter with TanStack Start, Eden Treaty, Better Auth, Drizzle, Stripe, Inngest, and Vercel deployment.
+- [Eden Stack](https://eden-stack.com) - Production-ready full-stack SaaS starter with TanStack Start, Eden Treaty, Better Auth, Drizzle, Stripe, Inngest, and Vercel deployment.
 - [elysia-routing-controllers](https://github.com/OthmanAmoudi/Elysia-routing-controllers) - Elysia RESTAPI routing controllers, Turso sqlite database with DrizzleORM.
 - [elysia-ws-event](https://github.com/Kiyo5hi/elysia-ws-event) - Event-drive Elysia WebSocket server.
 - [elysia-clean-architecture](https://github.com/lukas-andre/bun-elysia-clean-architecture-example) - ElysiaJS, Bun, Postgres.js + Clean Architecture API example


### PR DESCRIPTION
Eden Stack is a production-ready full-stack starter kit built on Elysia with Eden Treaty for type-safe API communication.

The Elysia server is embedded in TanStack Start via a catch-all route handler, with Better Auth mounted directly on it. It integrates Stripe webhooks, Inngest background jobs, Drizzle ORM with Neon PostgreSQL, and deploys to Vercel.

Site: https://eden-stack.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Eden Stack" to the Boilerplates list as an available option.
  * Described as a production-ready full-stack SaaS starter (includes example integrations for auth, database, payments, background jobs, and deployment) and linked to https://eden-stack.com for more details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->