### PR TITLE
Add Vision to Plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 - [compression](https://github.com/gusb3ll/elysia-compression) - Compression plugin.
 - [Logging](https://github.com/otherguy/elysia-logging) - Logging middleware for a variety of loggers (Pino, Winston, etc.)
 - [Apitally](https://github.com/apitally/apitally-js) - Simple API monitoring, analytics, and request logging.
+- [Vision](https://github.com/ephor/vision) - Meta-framework built on Elysia with a built-in observability dashboard — automatic tracing, live logs, and an API playground.
 
 ## License
 


### PR DESCRIPTION
Adds Vision — an open-source (MIT) observability layer for TypeScript APIs.

For Elysia users it ships as `@getvision/server`, a meta-framework built on Elysia (Elysia is a peer dependency) that adds an in-process dashboard: automatic tracing, live logs with trace context, and an API request playground. It also exports traces via OTLP, so the same data can go to any OpenTelemetry backend in production.

Placed it in Plugins next to other monitoring-adjacent entries (e.g. Apitally). Single entry, matched the existing line format.

Repo: https://github.com/ephor/vision

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/elysiajs/awesome-elysia/blob/main/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin entry for **Vision** in the plugins list.
  * Highlights an observability dashboard with automatic tracing, live logs, and an API playground.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->