### PR TITLE
Add @stitchapi/elysia

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 - [compression](https://github.com/gusb3ll/elysia-compression) - Compression plugin.
 - [Logging](https://github.com/otherguy/elysia-logging) - Logging middleware for a variety of loggers (Pino, Winston, etc.)
 - [Apitally](https://github.com/apitally/apitally-js) - Simple API monitoring, analytics, and request logging.
+- [@stitchapi/elysia](https://github.com/rejifald/StitchAPI/tree/main/packages/elysia) - Plugin that adds a StitchAPI seam to the context for typed outbound API calls, with per-request principal, SSE streaming, and error-to-HTTP mapping.
 
 ## License
 


### PR DESCRIPTION
Adds `@stitchapi/elysia` to the bottom of **Plugins**.

It's a plugin for [StitchAPI](https://stitchapi.dev): `.use()` it and each request's context gets a `seam` — a request-scoped, principal-bound handle for making typed, validated, resilient outbound API calls — plus an SSE bridge (`streamStitchSse`) and a StitchError → HTTP error mapping. Imports only `elysia` and `stitchapi` (no `node:*`), so it runs on Bun, Node, Deno and the edge.

Source: https://github.com/rejifald/StitchAPI/tree/main/packages/elysia

Checked against the guidelines: links to the GitHub repo, added to the bottom of the relevant category, description is plain (no tagline / not title-case), starts with a capital and ends with a period.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin entry in the Plugins section for `@stitchapi/elysia`.
  * The listing now highlights typed outbound calls, per-request principal handling, SSE streaming, and error-to-HTTP mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->