### PR TITLE
Update ShipKit entry: 11 production apps, canonical URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 - [elysia-supabase-tempate](https://github.com/boomNDS/elysia-supabase-tempate) - Elysia starter template that pairs Bun/Elysia with Supabase for auth and database tooling.
 - [vue-elysia](https://github.com/HkList/vue-elysia) - ElysiaJS, Bun, Drizzle, BullMQ; supports Vue and Nuxt; Clean Architecture.
 - [clean-elysia](https://github.com/aolus-software/clean-elysia) - ElysiaJS boilerplate with Drizzle Orm (Postgres), BullMQ (Queue), Redis (Cache).
-- [ShipKit](https://shipkit.davrapps.dev) - Full-stack SaaS monorepo boilerplate: ElysiaJS API + Next.js 16 frontend, Bun runtime, Better Auth, Drizzle ORM, shadcn/ui, Polar.sh payments, i18n, dark mode. Tested across 5 production apps.
+- [ShipKit](https://shipkit.davrapps.dev/en) - Full-stack SaaS monorepo boilerplate: ElysiaJS API + Next.js 16 frontend, Bun runtime, Better Auth, Drizzle ORM, shadcn/ui, Polar.sh payments, i18n, dark mode. Tested across 11 production apps.
 
 ## Plugins
 


### PR DESCRIPTION
The ShipKit line said "Tested across 5 production apps" — that number is stale. Eleven apps now run on the codebase; four of them are written up in depth with their package diffs against the boilerplate at https://shipkit.davrapps.dev/en/showcase.

Also points the link at /en, which is the canonical URL — the bare root 307-redirects there.

No new entry, no new section: this is an edit to the line that is already in Boilerplates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ShipKit boilerplate entry URL.
  * Updated the stated production usage from 5 to 11 apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->