### PR TITLE
Add starter-elysia to Boilerplates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 - [vue-elysia](https://github.com/HkList/vue-elysia) - ElysiaJS, Bun, Drizzle, BullMQ; supports Vue and Nuxt; Clean Architecture.
 - [clean-elysia](https://github.com/aolus-software/clean-elysia) - ElysiaJS boilerplate with Drizzle Orm (Postgres), BullMQ (Queue), Redis (Cache).
 - [ShipKit](https://shipkit.davrapps.dev/en) - Full-stack SaaS monorepo boilerplate: ElysiaJS API + Next.js 16 frontend, Bun runtime, Better Auth, Drizzle ORM, shadcn/ui, Polar.sh payments, i18n, dark mode. Tested across 11 production apps.
+- [starter-elysia](https://github.com/Fadhila36/starter-elysia) - A production-ready starter kit built with Elysia, Bun, Drizzle ORM, and Redis. Features secure auth and DDD.
 
 ## Plugins
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/elysiajs/awesome-elysia/blob/main/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

Adding a production-ready starter kit built with Elysia, Bun, Drizzle ORM, and Redis. Features Hexagonal Architecture, secure JWT auth (JTI rotation + Argon2id), and a strong TDD setup.