### PR TITLE
Add Elysia 2 vs NestJS 12 benchmark write-up to Articles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ A curated list of awesome things related to <a href='https://github.com/elysiajs
 - [BETH: A Modern Stack for the Modern Web](https://blog.stackademic.com/beth-a-modern-stack-for-the-modern-web-1b3f3effb537)
 - [Add JWT Authentication in Bun API](https://dev.to/harshmangalam/add-jwt-authentication-in-bun-api-488d)
 - [Deploy Elysia With CloudFlare Workers](https://medium.com/@mertenercan/how-to-deploy-elysiajs-app-on-cloudflare-workers-51cc459b078a)
+- [Elysia 2 vs NestJS 12: Runtime +64.6%, Framework +10.6%](https://shipkit.davrapps.dev/en/blog/elysia-2-vs-nestjs-12-what-each-layer-buys)
 
 ## Boilerplates
 


### PR DESCRIPTION
Adds one article to the Articles section, at the bottom, in the section's existing `[title](link)` format:

- [Elysia 2 vs NestJS 12: Runtime +64.6%, Framework +10.6%](https://shipkit.davrapps.dev/en/blog/elysia-2-vs-nestjs-12-what-each-layer-buys)

The same seven-route API on NestJS 12 + Fastify and on Elysia 2.0.0-beta.12, run in four configurations so each step changes one layer (runtime, framework, AOT build), with a measured noise floor, a cost model and a friction log. Harness, raw results and methodology are public at https://github.com/Dave93/elysia-vs-nest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rv1szjaUD91KoPs97x4cz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an article link comparing Elysia 2 and NestJS 12 runtime and framework performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->